### PR TITLE
Setup project requirements

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,7 +113,7 @@ jobs:
             pyyaml>=6.0
             esptool>=4.0.0
             pyserial>=3.5
-            EOF
+EOF
           else
             echo "$FILES" > req-list
           fi


### PR DESCRIPTION
Fix shell here-document syntax in security workflow by removing leading spaces from the `EOF` delimiter.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b815344-cc19-4287-82f0-bb7cfad015b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b815344-cc19-4287-82f0-bb7cfad015b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

