### PR TITLE
Fix bash heredoc indentation and quotes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -110,10 +110,10 @@ jobs:
           if [ -z "$FILES" ]; then
             echo "requirements.txt" > req-list
             cat > requirements.txt <<'EOF'
-            pyyaml>=6.0
-            esptool>=4.0.0
-            pyserial>=3.5
-            'EOF'
+pyyaml>=6.0
+esptool>=4.0.0
+pyserial>=3.5
+EOF
           else
             echo "$FILES" > req-list
           fi


### PR DESCRIPTION
Correct bash heredoc syntax in `security.yml` by removing content indentation and unquoting the closing marker.
