### PR TITLE
Organize documentation structure and hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+layout: default
+title: "🔧 HardFOC ESP32 CI Tools"
+description: "Advanced CI/CD Tools for HardFOC ESP32 Projects - Comprehensive GitHub Actions workflows for ESP-IDF development with matrix builds, security auditing, and automated documentation"
+nav_order: 1
+permalink: /
+---
+
 # 🔧 HardFOC ESP32 CI Tools
 
 <div align="center">

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,76 @@
+# Jekyll Configuration for HardFOC ESP32 CI Tools Documentation
+
+# Site settings
+title: "🔧 HardFOC ESP32 CI Tools"
+description: "Advanced CI/CD Tools for HardFOC ESP32 Projects - Comprehensive GitHub Actions workflows for ESP-IDF development with matrix builds, security auditing, and automated documentation"
+url: "https://n3b3x.github.io"
+baseurl: "/hf-espidf-ci-tools"
+
+# Build settings
+markdown: kramdown
+highlighter: rouge
+theme: just-the-docs
+
+# Just the Docs theme settings
+search_enabled: true
+search_heading_level: 2
+search_boost_heading_level: 1
+search_boost_content: 1
+search_boost_title: 2
+search_boost_href: 1.5
+search_boost_relative: 1
+
+# Navigation
+aux_links:
+  "GitHub Repository":
+    - "https://github.com/N3b3x/hf-espidf-ci-tools"
+
+# Footer content
+footer_content: "Built with <a href=\"https://github.com/just-the-docs/just-the-docs\">Just the Docs</a>, a Jekyll theme for documentation sites."
+
+# Color scheme
+color_scheme: light
+
+# Plugins
+plugins:
+  - jekyll-feed
+  - jekyll-sitemap
+  - jekyll-seo-tag
+
+# Exclude files from processing
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - hf-espidf-project-tools/
+  - path/
+  - .github/
+  - README.md
+
+# Include files
+include:
+  - _pages
+
+# Collections
+collections:
+  docs:
+    output: true
+    permalink: /:path/
+
+# Default front matter
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: "default"
+  - scope:
+      path: ""
+      type: "docs"
+    values:
+      layout: "default"
+      parent: "Documentation"

--- a/_pages/documentation.md
+++ b/_pages/documentation.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: "Documentation"
+description: "Complete documentation for HardFOC ESP32 CI Tools"
+nav_order: 2
+has_children: true
+permalink: /docs/
+---
+
+# Documentation
+
+Welcome to the HardFOC ESP32 CI Tools documentation! This section contains comprehensive guides for using the CI/CD workflows in your ESP32 projects.
+
+## Available Guides
+
+- **[Documentation Index](index.md)** - Complete navigation and setup guide
+- **[Build Workflow](build-workflow.md)** - ESP-IDF matrix builds with caching
+- **[Security Workflow](security-workflow.md)** - Dependencies, secrets, and CodeQL analysis
+- **[Example Workflows](example-workflows.md)** - Ready-to-use workflow templates
+
+## Quick Start
+
+1. **Choose your workflow** based on your project needs
+2. **Read the individual guides** for detailed configuration
+3. **Customize inputs** to match your project structure
+4. **Test with a simple workflow** before adding complexity
+
+## Getting Help
+
+- Check the [troubleshooting sections](build-workflow.md#-troubleshooting) in each guide
+- Review the [example workflows](example-workflows.md) for common patterns
+- Open an issue on the [GitHub repository](https://github.com/N3b3x/hf-espidf-ci-tools) for support

--- a/docs/build-workflow.md
+++ b/docs/build-workflow.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🏗️ ESP-IDF Build Workflow Guide"
+description: "Advanced ESP32 Build System for HardFOC Projects - Matrix-based building across multiple ESP-IDF versions, build types, and applications with intelligent caching and artifact management"
+nav_order: 3
+parent: "Documentation"
+permalink: /docs/build-workflow/
+---
+
 # 🏗️ ESP-IDF Build Workflow Guide
 
 <div align="center">

--- a/docs/example-workflows.md
+++ b/docs/example-workflows.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🚀 Example Workflows for Consumer Repositories"
+description: "Complete workflow examples for HardFOC ESP32 projects - Ready-to-use GitHub Actions workflows that leverage all CI tools in parallel"
+nav_order: 5
+parent: "Documentation"
+permalink: /docs/example-workflows/
+---
+
 # 🚀 Example Workflows for Consumer Repositories
 
 <div align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "📚 Documentation Index"
+description: "Complete documentation navigation and setup guide for HardFOC ESP32 CI Tools"
+nav_order: 2
+parent: "Documentation"
+permalink: /docs/
+---
+
 # Documentation Index
 
 <div align="center">

--- a/docs/security-workflow.md
+++ b/docs/security-workflow.md
@@ -1,3 +1,12 @@
+---
+layout: default
+title: "🛡️ Security Workflow Guide"
+description: "Comprehensive security auditing for HardFOC ESP32 projects - Dependencies, secrets, and CodeQL analysis with automatic requirements discovery"
+nav_order: 4
+parent: "Documentation"
+permalink: /docs/security-workflow/
+---
+
 # Security Workflow Guide
 
 <div align="center">


### PR DESCRIPTION
Add Jekyll front matter to all markdown files and configure Jekyll to enable structured documentation publication.

This PR prepares the repository for Jekyll-based documentation publication by adding necessary front matter to markdown files for proper ordering, parenting, and permalinks, with the main `README.md` serving as the root permalink (`/`). It also includes the `_config.yml` and a parent `_pages/documentation.md` for the Jekyll setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-db142862-81c3-4c4f-a929-b290cfe6e846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db142862-81c3-4c4f-a929-b290cfe6e846">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

