### PR TITLE
Config loader multiline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "hf-espidf-project-tools"]
 	path = hf-espidf-project-tools
 	url = https://github.com/N3b3x/hf-espidf-project-tools.git
+	branch = fix/config-parser-multiline-yaml


### PR DESCRIPTION
Update `config_loader.sh` to correctly parse multiline YAML configurations in the `yq` fallback.

This fixes CI failures where `yq` is unavailable and `app_config.yml` uses multiline YAML for `build_types` or other deeply nested fields. The previous `grep -A 10` context was insufficient for deeply nested fields, and it incorrectly assumed inline array formats, leading to parsing failures.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e5ed4171-a06b-4349-b7c3-d313ab497719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5ed4171-a06b-4349-b7c3-d313ab497719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

